### PR TITLE
Update to Nginx Gateway Fabric 2.6.5 and OrbStack 2.2.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The purpose of this example is to provide instructions for running the Dockercoi
 
 ## Software Requirements
 
-- OrbStack 2.0.5 or newer
+- OrbStack 2.2.1 or newer
 
 - K3d 5.8.3 or newer
 
@@ -25,7 +25,7 @@ The purpose of this example is to provide instructions for running the Dockercoi
 2.  install K8s Gateway API resources
 
     ```zsh
-    kubectl kustomize "https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.5.1" | kubectl apply -f -
+    kubectl kustomize "https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.6.5" | kubectl apply -f -
     ```
 
 3.  deploy Nginx Gateway Fabric


### PR DESCRIPTION
This PR supports the following features:

- update to Nginx Gateway Fabric 2.6.5
- update to OrbStack 2.2.1